### PR TITLE
Add minimal frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,5 @@ Send a `POST` request to `/decrypt` with one or more files. The service responds
 
 Run the application with `mvn spring-boot:run` and send a `POST` request to `http://localhost:8080/decrypt` with your files.
 
-This project no longer includes the sample HTML upload form. Interact with the service using HTTP tools such as `curl` or Postman.
+You can also open `http://localhost:8080/index.html` in your browser to use a basic front‑end
+upload form that posts to the same backend.

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Decrypt Files</title>
+</head>
+<body>
+    <h1>Decrypt Files</h1>
+    <form id="decryptForm">
+        <input type="file" id="files" name="files" multiple required><br/>
+        <label for="mode">Mode:</label>
+        <select id="mode" name="mode">
+            <option value="stream">Stream</option>
+            <option value="path">Path</option>
+        </select>
+        <button type="submit">Decrypt</button>
+    </form>
+    <pre id="output"></pre>
+    <script>
+        const form = document.getElementById('decryptForm');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const filesInput = document.getElementById('files');
+            const mode = document.getElementById('mode').value;
+            const formData = new FormData();
+            for (const file of filesInput.files) {
+                formData.append('files', file);
+            }
+            formData.append('mode', mode);
+            try {
+                const response = await fetch('/decrypt', {
+                    method: 'POST',
+                    body: formData
+                });
+                const data = await response.json();
+                document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+            } catch (err) {
+                document.getElementById('output').textContent = 'Error: ' + err;
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement a simple HTML upload form that targets `/decrypt`
- document how to access the front-end

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b317362448325a728bf44d4effeed